### PR TITLE
Add tests for unsigned HTTP routes

### DIFF
--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1,0 +1,55 @@
+from decimal import Decimal
+
+from gswap_sdk.assets import Assets
+
+
+class DummyHttpClient:
+    def __init__(self, payload):
+        self.payload = payload
+        self.calls = []
+
+    def send_get_request(self, base_url, base_path, endpoint, params):
+        self.calls.append((base_url, base_path, endpoint, params))
+        return self.payload
+
+
+def test_get_user_assets_parses_response():
+    payload = {
+        "data": {
+            "token": [
+                {
+                    "image": "image-a",
+                    "name": "Token A",
+                    "decimals": 18,
+                    "verify": True,
+                    "symbol": "TKNA",
+                    "quantity": "1.5000",
+                },
+                {
+                    "image": "image-b",
+                    "name": "Token B",
+                    "decimals": 6,
+                    "verify": False,
+                    "symbol": "TKNB",
+                    "quantity": 42,
+                },
+            ],
+            "count": 2,
+        }
+    }
+    http_client = DummyHttpClient(payload)
+    assets = Assets("https://dex-backend.example", http_client)
+
+    result = assets.get_user_assets(" eth|wallet ", page=2, limit=5)
+
+    assert http_client.calls[0] == (
+        "https://dex-backend.example",
+        "/user/assets",
+        "",
+        {"address": "eth|wallet", "page": "2", "limit": "5"},
+    )
+    assert len(result.tokens) == 2
+    assert result.tokens[0].quantity == Decimal("1.5000")
+    assert result.tokens[1].quantity == Decimal("42")
+    assert result.tokens[0].verify is True
+    assert result.count == 2

--- a/tests/test_pools.py
+++ b/tests/test_pools.py
@@ -1,0 +1,46 @@
+from decimal import Decimal
+
+from gswap_sdk.pools import Pools
+
+
+class DummyHttpClient:
+    def __init__(self, payload):
+        self.payload = payload
+        self.calls = []
+
+    def send_post_request(self, base_url, base_path, endpoint, body):
+        self.calls.append((base_url, base_path, endpoint, body))
+        return {"Data": self.payload}
+
+
+def test_get_pool_data_parses_response():
+    payload = {
+        "bitmap": {"0": "1"},
+        "fee": "3000",
+        "feeGrowthGlobal0": "1000000",
+        "feeGrowthGlobal1": "2000000",
+        "grossPoolLiquidity": "500000000000000000",
+        "liquidity": "400000000000000000",
+        "maxLiquidityPerTick": "999",
+        "protocolFees": "1",
+        "protocolFeesToken0": "123456",
+        "protocolFeesToken1": "654321",
+        "sqrtPrice": "1.2",
+        "tickSpacing": "60",
+        "token0": "GALA|Unit|none|none",
+        "token1": "GUSDC|Unit|none|none",
+        "token0ClassKey": {"Collection": "GALA"},
+        "token1ClassKey": {"Collection": "GUSDC"},
+    }
+    http_client = DummyHttpClient(payload)
+    pools = Pools("https://gateway.example/", "/dex", http_client)
+
+    result = pools.get_pool_data("GALA|Unit|none|none", "GUSDC|Unit|none|none", 3000)
+
+    assert http_client.calls[0][2] == "/GetPoolData"
+    assert result.fee == 3000
+    assert result.sqrt_price == Decimal("1.2")
+    assert result.protocol_fees_token0 == Decimal("123456")
+    assert result.protocol_fees_token1 == Decimal("654321")
+    assert result.token0 == "GALA|Unit|none|none"
+    assert result.token1 == "GUSDC|Unit|none|none"

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -1,0 +1,133 @@
+from decimal import Decimal
+
+from gswap_sdk.positions import Positions
+
+
+class DummyBundler:
+    pass
+
+
+class DummyPools:
+    pass
+
+
+class DummyHttpClient:
+    def __init__(self, responses):
+        self.responses = responses
+        self.calls = []
+
+    def send_post_request(self, base_url, base_path, endpoint, body):
+        self.calls.append((base_url, base_path, endpoint, body))
+        return self.responses[endpoint]
+
+
+def _build_positions_service(responses):
+    return Positions(
+        "https://gateway.example",
+        "/dex",
+        DummyBundler(),
+        DummyPools(),
+        DummyHttpClient(responses),
+    )
+
+
+def test_get_user_positions_parses_response():
+    responses = {
+        "/GetUserPositions": {
+            "Data": {
+                "positions": [
+                    {
+                        "poolHash": "hash",
+                        "positionId": "pos-1",
+                        "token0ClassKey": "GALA|Unit|none|none",
+                        "token1ClassKey": "GUSDC|Unit|none|none",
+                        "token0Img": "image0",
+                        "token1Img": "image1",
+                        "token0Symbol": "GALA",
+                        "token1Symbol": "GUSDC",
+                        "fee": 3000,
+                        "liquidity": "1000",
+                        "tickLower": -120,
+                        "tickUpper": 120,
+                        "createdAt": "2023-01-01",
+                    }
+                ],
+                "nextBookMark": "bookmark",
+            }
+        }
+    }
+    service = _build_positions_service(responses)
+
+    result = service.get_user_positions(" eth|wallet ")
+
+    call = service.http_client.calls[0]
+    assert call[2] == "/GetUserPositions"
+    assert call[3]["user"] == "eth|wallet"
+    assert len(result.positions) == 1
+    assert result.positions[0].fee == 3000
+    assert result.bookmark == "bookmark"
+
+
+def test_get_position_parses_response():
+    responses = {
+        "/GetPositions": {
+            "Data": {
+                "fee": 3000,
+                "feeGrowthInside0Last": "10",
+                "feeGrowthInside1Last": "20",
+                "liquidity": "1000",
+                "poolHash": "hash",
+                "positionId": "pos-1",
+                "tickLower": -120,
+                "tickUpper": 120,
+                "token0ClassKey": "GALA|Unit|none|none",
+                "token1ClassKey": "GUSDC|Unit|none|none",
+                "tokensOwed0": "5",
+                "tokensOwed1": "6",
+            }
+        }
+    }
+    service = _build_positions_service(responses)
+
+    result = service.get_position(
+        "eth|wallet",
+        {
+            "token0ClassKey": "GALA|Unit|none|none",
+            "token1ClassKey": "GUSDC|Unit|none|none",
+            "fee": 3000,
+            "tickLower": -120,
+            "tickUpper": 120,
+        },
+    )
+
+    assert service.http_client.calls[0][2] == "/GetPositions"
+    assert result.tokens_owed0 == Decimal("5")
+    assert result.tokens_owed1 == Decimal("6")
+    assert result.token0_class_key.collection == "GALA"
+    assert result.token1_class_key.collection == "GUSDC"
+
+
+def test_estimate_remove_liquidity_parses_amounts():
+    responses = {
+        "/GetRemoveLiquidityEstimation": {
+            "Data": {"amount0": "1.5", "amount1": "2.5"}
+        }
+    }
+    service = _build_positions_service(responses)
+
+    result = service.estimate_remove_liquidity(
+        "eth|wallet",
+        "pos-1",
+        "GALA|Unit|none|none",
+        "GUSDC|Unit|none|none",
+        3000,
+        -120,
+        120,
+        Decimal("1"),
+    )
+
+    call = service.http_client.calls[0]
+    assert call[2] == "/GetRemoveLiquidityEstimation"
+    assert call[3]["owner"] == "eth|wallet"
+    assert result["amount0"] == Decimal("1.5")
+    assert result["amount1"] == Decimal("2.5")


### PR DESCRIPTION
## Summary
- add unit tests covering asset, pool, and position endpoints that do not require signing
- ensure responses from unsigned routes are parsed into Decimal-rich SDK structures

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d464610fc48331a014eb714575dfc6