### PR TITLE
Add pool graph cache for arbitrage searches

### DIFF
--- a/python-gswap-arb/README.md
+++ b/python-gswap-arb/README.md
@@ -26,6 +26,31 @@
 
 3. **Explore strategy development** by importing `gswap_arb` in a Python session and building workflows that re-use the core SDK clients. Because the project depends on `python-gswap-sdk`, all signed transactions and REST helpers are immediately available.
 
+## Configuring pool universes
+
+The GalaChain gateway does not enumerate every pool automatically. Operators must supply the token class keys and fee tiers they
+care about before the arbitrage helpers can reason about routes. The new `gswap_arb.pools.PoolGraph` module accepts this seed
+configuration, validates each edge via `client.pools.get_pool_data`, and caches the resulting tick spacing and liquidity with
+freshness timestamps. Typical usage looks like:
+
+```python
+from gswap_sdk.gswap import GSwap
+from gswap_arb.pools import PoolGraph
+
+client = GSwap()
+graph = PoolGraph(client)
+graph.hydrate([
+    ("collection|category|type|GALA", "collection|category|type|ETH", 3000),
+    ("collection|category|type|ETH", "collection|category|type|USDC", 500),
+])
+
+first_hop = graph.get_neighbors("collection|category|type|GALA")
+two_hop_tokens = graph.k_hop_neighbors("collection|category|type|GALA", max_hops=2)
+```
+
+By curating this universe up front, operators avoid redundant gateway calls while still receiving refreshed liquidity data on a
+configurable cadence.
+
 ## Tooling
 
 The repository configures Black, Ruff, MyPy, and Pytest via `pyproject.toml`. These tools enforce formatting, type safety, linting, and fast feedback loops, respectively. Continuous integration stubs mirror the SDK's decimal-first philosophy by ensuring every workflow validates Decimal precision before running project checks.

--- a/python-gswap-arb/gswap_arb/__init__.py
+++ b/python-gswap-arb/gswap_arb/__init__.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 from decimal import Clamped, Decimal, getcontext
 
-__all__ = ["configure_decimal_context"]
+from .pools import HydratedPoolEdge, PoolGraph, PoolSeed
+
+__all__ = [
+    "configure_decimal_context",
+    "HydratedPoolEdge",
+    "PoolGraph",
+    "PoolSeed",
+]
 
 
 def configure_decimal_context(precision: int = 28) -> None:

--- a/python-gswap-arb/gswap_arb/pools.py
+++ b/python-gswap-arb/gswap_arb/pools.py
@@ -1,0 +1,194 @@
+"""Pool graph hydration helpers for arbitrage workflows."""
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Deque, Dict, Iterable, Mapping, MutableMapping, Protocol, Sequence, Set, Tuple
+
+from gswap_sdk.pools import PoolData
+from gswap_sdk.token import (
+    GalaChainTokenClassKey,
+    parse_token_class_key,
+    stringify_token_class_key,
+)
+
+__all__ = [
+    "PoolSeed",
+    "HydratedPoolEdge",
+    "PoolGraph",
+]
+
+TokenLike = GalaChainTokenClassKey | str
+PoolSeed = Tuple[TokenLike, TokenLike, int]
+
+
+class PoolsClient(Protocol):
+    """Minimal client protocol required for pool hydration."""
+
+    def get_pool_data(
+        self,
+        token0: GalaChainTokenClassKey | str,
+        token1: GalaChainTokenClassKey | str,
+        fee: int,
+    ) -> PoolData:
+        """Return the latest on-chain state for a pool."""
+
+
+class SupportsPools(Protocol):
+    """Typing helper for objects that expose a ``pools`` attribute."""
+
+    pools: PoolsClient
+
+
+@dataclass(slots=True)
+class HydratedPoolEdge:
+    """Representation of a validated pool edge in the arbitrage graph."""
+
+    token0: GalaChainTokenClassKey
+    token1: GalaChainTokenClassKey
+    fee: int
+    tick_spacing: int
+    liquidity: Decimal
+    gross_liquidity: Decimal
+    last_refreshed: datetime
+
+    def token_strings(self) -> Tuple[str, str]:
+        """Return the canonical string identifiers for the pool tokens."""
+
+        return (
+            stringify_token_class_key(self.token0),
+            stringify_token_class_key(self.token1),
+        )
+
+    def other_token(self, token: str) -> GalaChainTokenClassKey:
+        """Return the token on the opposite side of ``token`` for the edge."""
+
+        token0, token1 = self.token_strings()
+        if token == token0:
+            return self.token1
+        if token == token1:
+            return self.token0
+        raise KeyError(f"Token {token!r} is not part of this pool edge")
+
+
+class PoolGraph:
+    """Cache of validated pools seeded from operator configuration."""
+
+    def __init__(
+        self,
+        client: SupportsPools,
+        *,
+        freshness: timedelta = timedelta(minutes=5),
+    ) -> None:
+        if freshness <= timedelta(0):
+            raise ValueError("freshness must be a positive timedelta")
+
+        self._client = client
+        self._freshness = freshness
+        self._edges: Dict[Tuple[str, str, int], HydratedPoolEdge] = {}
+        self._adjacency: Dict[str, Set[Tuple[str, str, int]]] = defaultdict(set)
+
+    def hydrate(self, seeds: Iterable[PoolSeed]) -> None:
+        """Hydrate the configured pool edges via the gateway API."""
+
+        now = datetime.now(timezone.utc)
+        for seed in seeds:
+            token_a, token_b, fee = seed
+            parsed_a = parse_token_class_key(token_a)
+            parsed_b = parse_token_class_key(token_b)
+            token0_str, token1_str = sorted(
+                (
+                    stringify_token_class_key(parsed_a),
+                    stringify_token_class_key(parsed_b),
+                )
+            )
+            edge_key = (token0_str, token1_str, int(fee))
+
+            existing = self._edges.get(edge_key)
+            if existing and now - existing.last_refreshed < self._freshness:
+                continue
+
+            pool_data = self._client.pools.get_pool_data(parsed_a, parsed_b, int(fee))
+            api_tokens = {
+                stringify_token_class_key(pool_data.token0),
+                stringify_token_class_key(pool_data.token1),
+            }
+            if {token0_str, token1_str} != api_tokens:
+                raise ValueError(
+                    "Gateway returned mismatched token class keys for pool edge",
+                )
+
+            token0 = parse_token_class_key(token0_str)
+            token1 = parse_token_class_key(token1_str)
+            hydrated = HydratedPoolEdge(
+                token0=token0,
+                token1=token1,
+                fee=int(pool_data.fee),
+                tick_spacing=int(pool_data.tick_spacing),
+                liquidity=pool_data.liquidity,
+                gross_liquidity=pool_data.gross_pool_liquidity,
+                last_refreshed=now,
+            )
+            self._edges[edge_key] = hydrated
+            self._adjacency[token0_str].add(edge_key)
+            self._adjacency[token1_str].add(edge_key)
+
+    def get_neighbors(self, token: TokenLike) -> Sequence[HydratedPoolEdge]:
+        """Return hydrated pool edges incident to ``token``."""
+
+        token_str = stringify_token_class_key(token)
+        keys = self._adjacency.get(token_str)
+        if not keys:
+            return []
+        return [self._edges[key] for key in keys]
+
+    def k_hop_neighbors(
+        self, token: TokenLike, *, max_hops: int
+    ) -> Mapping[int, Set[str]]:
+        """Return tokens reachable within ``max_hops`` steps of ``token``."""
+
+        if max_hops < 1:
+            return {}
+
+        start = stringify_token_class_key(token)
+        visited: Set[str] = {start}
+        frontier: Deque[Tuple[str, int]] = deque([(start, 0)])
+        layers: MutableMapping[int, Set[str]] = defaultdict(set)
+
+        while frontier:
+            current, depth = frontier.popleft()
+            if depth == max_hops:
+                continue
+
+            for edge_key in self._adjacency.get(current, set()):
+                edge = self._edges[edge_key]
+                neighbor = stringify_token_class_key(edge.other_token(current))
+                if neighbor in visited:
+                    continue
+                visited.add(neighbor)
+                layers[depth + 1].add(neighbor)
+                frontier.append((neighbor, depth + 1))
+
+        return {hop: set(tokens) for hop, tokens in layers.items()}
+
+    def edge_count(self) -> int:
+        """Return the number of hydrated edges currently cached."""
+
+        return len(self._edges)
+
+    def last_refreshed(self, token_a: TokenLike, token_b: TokenLike, fee: int) -> datetime | None:
+        """Return the last hydration timestamp for the specified edge."""
+
+        parsed_a = parse_token_class_key(token_a)
+        parsed_b = parse_token_class_key(token_b)
+        token0_str, token1_str = sorted(
+            (
+                stringify_token_class_key(parsed_a),
+                stringify_token_class_key(parsed_b),
+            )
+        )
+        edge_key = (token0_str, token1_str, int(fee))
+        edge = self._edges.get(edge_key)
+        return edge.last_refreshed if edge else None

--- a/python-gswap-arb/tests/test_pools.py
+++ b/python-gswap-arb/tests/test_pools.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from decimal import Decimal
+from typing import List, Tuple
+
+import pytest
+
+from gswap_arb.pools import PoolGraph
+from gswap_sdk.pools import PoolData
+from gswap_sdk.token import stringify_token_class_key
+
+TOKEN_A = "collection|category|type|AAA"
+TOKEN_B = "collection|category|type|BBB"
+TOKEN_C = "collection|category|type|CCC"
+
+
+def _make_pool_data(token0: str, token1: str, fee: int) -> PoolData:
+    return PoolData(
+        bitmap={},
+        fee=fee,
+        fee_growth_global0=Decimal("0"),
+        fee_growth_global1=Decimal("0"),
+        gross_pool_liquidity=Decimal("2000"),
+        liquidity=Decimal("1000"),
+        max_liquidity_per_tick=Decimal("0"),
+        protocol_fees=0,
+        protocol_fees_token0=Decimal("0"),
+        protocol_fees_token1=Decimal("0"),
+        sqrt_price=Decimal("1"),
+        tick_spacing=60,
+        token0=token0,
+        token0_class_key={},
+        token1=token1,
+        token1_class_key={},
+    )
+
+
+class RecordingPools:
+    def __init__(self) -> None:
+        self.requests: List[Tuple[str, str, int]] = []
+
+    def get_pool_data(self, token0, token1, fee) -> PoolData:
+        token_strings = sorted(
+            (
+                stringify_token_class_key(token0),
+                stringify_token_class_key(token1),
+            )
+        )
+        self.requests.append(
+            (
+                stringify_token_class_key(token0),
+                stringify_token_class_key(token1),
+                int(fee),
+            )
+        )
+        return _make_pool_data(token_strings[0], token_strings[1], int(fee))
+
+
+class MismatchedPools(RecordingPools):
+    def get_pool_data(self, token0, token1, fee) -> PoolData:  # type: ignore[override]
+        super().get_pool_data(token0, token1, fee)
+        # Force an unexpected token to trigger validation
+        return _make_pool_data(TOKEN_A, "different|token|class|key", int(fee))
+
+
+class Client:
+    def __init__(self, pools) -> None:
+        self.pools = pools
+
+
+def test_hydrate_builds_graph_and_caches_results() -> None:
+    pools = RecordingPools()
+    graph = PoolGraph(Client(pools), freshness=timedelta(minutes=10))
+
+    graph.hydrate([(TOKEN_A, TOKEN_B, 3_000)])
+
+    assert pools.requests == [(TOKEN_A, TOKEN_B, 3_000)]
+    assert graph.edge_count() == 1
+
+    neighbors = graph.get_neighbors(TOKEN_A)
+    assert len(neighbors) == 1
+    edge = neighbors[0]
+    assert edge.tick_spacing == 60
+    assert edge.liquidity == Decimal("1000")
+    assert edge.gross_liquidity == Decimal("2000")
+    assert graph.last_refreshed(TOKEN_A, TOKEN_B, 3_000) is not None
+
+    graph.hydrate([(TOKEN_A, TOKEN_B, 3_000)])
+    assert len(pools.requests) == 1
+
+
+def test_k_hop_neighbors_discovers_tokens_within_depth() -> None:
+    pools = RecordingPools()
+    graph = PoolGraph(Client(pools), freshness=timedelta(minutes=10))
+    graph.hydrate([(TOKEN_A, TOKEN_B, 500), (TOKEN_B, TOKEN_C, 500)])
+
+    first_hop = graph.k_hop_neighbors(TOKEN_A, max_hops=1)
+    assert first_hop == {1: {TOKEN_B}}
+
+    second_hop = graph.k_hop_neighbors(TOKEN_A, max_hops=2)
+    assert second_hop[1] == {TOKEN_B}
+    assert second_hop[2] == {TOKEN_C}
+
+
+def test_hydrate_raises_when_gateway_returns_unexpected_tokens() -> None:
+    graph = PoolGraph(Client(MismatchedPools()), freshness=timedelta(minutes=10))
+
+    with pytest.raises(ValueError):
+        graph.hydrate([(TOKEN_A, TOKEN_B, 500)])


### PR DESCRIPTION
## Summary
- add a PoolGraph helper that hydrates operator-provided token/fee pairs and caches liquidity metadata
- provide tests covering hydration caching, k-hop traversal, and token validation failures
- document how to seed the pool universe for arbitrage experiments

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68ded9d423e483318234df5594a53d30